### PR TITLE
No project.properties file?

### DIFF
--- a/Library/project.properties
+++ b/Library/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-8
+target=android-17
 android.library=true


### PR DESCRIPTION
Is there a reason that this repo doesn't have a project.properties file? Not having one makes it more difficult to use this repo as a submodule.

See issue https://github.com/6wunderkinder/android-sliding-layer-lib/issues/15
