### PR TITLE
Removed import from sample project in main library

### DIFF
--- a/Library/src/com/slidinglayer/SlidingLayer.java
+++ b/Library/src/com/slidinglayer/SlidingLayer.java
@@ -47,8 +47,6 @@ import android.view.animation.Interpolator;
 import android.widget.FrameLayout;
 import android.widget.Scroller;
 
-import com.slidinglayersample.R;
-
 public class SlidingLayer extends FrameLayout {
 
     // TODO Document


### PR DESCRIPTION
Fixed the issue introduced here: https://github.com/6wunderkinder/android-sliding-layer-lib/commit/77240802278c5516c35488568b7552e00d4ce248#L0R50

The library should compile properly now.
