### PR TITLE
remove usless but affect performance code

### DIFF
--- a/Library/src/com/slidinglayer/SlidingLayer.java
+++ b/Library/src/com/slidinglayer/SlidingLayer.java
@@ -937,7 +937,6 @@ public class SlidingLayer extends FrameLayout {
     public void setDrawingCacheEnabled(boolean enabled) {
 
         if (mDrawingCacheEnabled != enabled) {
-            super.setDrawingCacheEnabled(enabled);
             mDrawingCacheEnabled = enabled;
 
             final int l = getChildCount();


### PR DESCRIPTION
When the SlidingLayer is Sliding,it will call `invalidate` frequently。So set this SlidingLayer's DrawingCacheEnabled true is usless and affect performance.But set  the DrawingCacheEnabled of  SlidingLayer's child view true will make sliding smooth.
